### PR TITLE
Fixed the ShippingAddress deserialization error

### DIFF
--- a/Chargily.Pay/Internal/JsonConverters/ShippingAddressToStringConverter.cs
+++ b/Chargily.Pay/Internal/JsonConverters/ShippingAddressToStringConverter.cs
@@ -1,0 +1,53 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Chargily.Pay.Internal.JsonConverters
+{
+    internal class ShippingAddressToStringConverter : JsonConverter<string>
+    {
+        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null) return null;
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                string? state = null;
+                string? address = null;
+                string country = string.Empty;
+
+                while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+                {
+                    if (reader.TokenType == JsonTokenType.PropertyName)
+                    {
+                        string propertyName = reader.GetString();
+                        reader.Read();
+                        switch (propertyName)
+                        {
+                            case "country":
+                                country = reader.GetString();
+                                break;
+                            case "state":
+                                state = reader.GetString();
+                                break;
+                            case "address":
+                                address = reader.GetString();
+                                break;
+                            
+                        }
+                    }
+                }
+                string result = country;
+                result += !string.IsNullOrEmpty(state) ? $", {state}" : string.Empty;
+                result += !string.IsNullOrEmpty(address) ? $", {address}" : string.Empty;
+
+                return result;
+            }
+            throw new JsonException("Expected a JSON object or null");
+        }
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Chargily.Pay/Internal/Responses/CheckoutApiResponse.cs
+++ b/Chargily.Pay/Internal/Responses/CheckoutApiResponse.cs
@@ -28,6 +28,7 @@ internal record CheckoutApiResponse : BaseObjectApiResponse
     [JsonPropertyName("checkout_url")] public string? CheckoutUrl { get; init; }
     
     [JsonPropertyName("shipping_address")]
+    [JsonConverter(typeof(ShippingAddressToStringConverter))]
     public string? ShippingAddress { get; init; }
     
     [JsonPropertyName("collect_shipping_address")]


### PR DESCRIPTION
There seemed be an error with the deserialization functionality of the `CheckoutApiResponse` class specifically when it comes to deserializing the `ShippingAddress` field, since the Api responses with a JWT as follows:

```Json
{
  "livemode": false,
  "id": "01jv932t26p75pntzoq4723bbwj",
  "entity": "checkout",
  "amount": 42000,
  "currency": "dzd",
  "fees": 0,
  "fees_on_merchant": 0,
  "fees_on_customer": 0,
  "pass_fees_to_customer": 1,
  "chargily_pay_fees_allocation": null,
  "status": "paid",
  "fulfillment_status": "unfulfilled",
  "deposit_transaction_id": "9796",
  "locale": "ar",
  "description": "23/10/2024 4:24:07 PM",
  "metadata": [],
  "success_url": "",
  "failure_url": "https://patron-site.web.app/",
  "webhook_endpoint": "https://patron-site.web.app/",
  "payment_method": "edahabia",
  "invoice_id": null,
  "customer_id": "01aaf4tb06045b698dvsgb74m7",
  "payment_link_id": null,
  "created_at": 1729700648,
  "updated_at": 1729700692,
/* The ShippingAddress field is a nested Json object instead of a string. */
  "shipping_address": { 
    "state": "المسيلة",
    "address": "المسيلة",
    "country": "dz"
  },
  "collect_shipping_address": 1,
  "discount": null,
  "amount_without_discount": 0,
  "checkout_url": "https://pay.chargily.dz/test/checkouts/01jax32n6p75pnhzqtg723bbwj/pay"
}
```

Apparently the package's runtime expects the value to be a string but the case is otherwise:

```C#
[JsonPropertyName("shipping_address")]
public string? ShippingAddress { get; init; }
```

I took it upon myself to fix the issue which I really hope would be okay by the owners of this repo, and I wish from the bottom of my heart that my fork will be pulled. I am also open-minded for any remarks or directions and especially very humbled by your amazing work which has showed me various new techniques.

Best regards.